### PR TITLE
Allow specifying update frequency and S3 URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Only SSH access is allowed to Bastion host.
   * s3_bucket_name - S3 bucket name which contains public keys (see `samples/s3_ssh_public_keys.tf`)
   * vpc_id - VPC where bastion host should be created
   * subnet_id - Subnet ID where instance should be created
-  * enable_hourly_cron_updates - Enable hourly crontab updates from S3 bucket (default, `false`)
+  * keys_update_frequency - How often to update keys. A cron timespec or an empty string to turn off (default).
   * additional_user_data_script - Additional user-data script to run at the end.
 
 ## Outputs:
@@ -38,7 +38,7 @@ Basic example - In your terraform code add something like this:
       s3_bucket_name              = "public-keys-demo-bucket"
       vpc_id                      = "vpc-123456"
       subnet_id                   = "subnet-123456"
-      enable_hourly_cron_updates  = true
+      keys_update_frequency       = "5,20,35,50 * * * *"
       additional_user_data_script = "date"
     }
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Only SSH access is allowed to the bastion host.
   * region - Region (default, `eu-west-1`)
   * iam_instance_profile - IAM instance profile which is allowed to access S3 bucket (see `samples/iam.tf`)
   * s3_bucket_name - S3 bucket name which contains public keys (see `samples/s3_ssh_public_keys.tf`)
-  * s3_bucket_uri – S3 URI which contains the public keys. If this is specified, `s3_bucket_name` will be ignored.
+  * s3_bucket_uri – S3 URI which contains the public keys. If specified, `s3_bucket_name` will be ignored.
   * vpc_id - VPC where bastion host should be created
   * subnet_id - Subnet ID where instance should be created
   * keys_update_frequency - How often to update keys. A cron timespec or an empty string to turn off (default).
@@ -29,6 +29,7 @@ Only SSH access is allowed to the bastion host.
   * instance_id - Bastion instance ID
   * ssh_user - SSH user to login to bastion
   * instance_ip - Public IP of bastion instance
+  * security_group_id - ID of the security group the bastion host is launched in.
 
 ## Example:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # tf_aws_bastion_s3_keys
 
-A Terraform module for creating bastion host on AWS EC2 and populate its ~/.ssh/authorized_keys with public keys fetched from S3 bucket.
+A Terraform module for creating bastion host on AWS EC2 and populate its
+~/.ssh/authorized_keys with public keys fetched from S3 bucket.
 
-This module can append public keys, setup cron to update them and run additional commands at the end of setup.
+This module can append public keys, setup cron to update them and run
+additional commands at the end of setup. Note that if it is set up to
+update the keys, removing a key from the bucket will also remove it from
+the bastion host.
 
-Only SSH access is allowed to Bastion host. 
+Only SSH access is allowed to the bastion host.
 
 ## Input variables:
 
@@ -14,6 +18,7 @@ Only SSH access is allowed to Bastion host.
   * region - Region (default, `eu-west-1`)
   * iam_instance_profile - IAM instance profile which is allowed to access S3 bucket (see `samples/iam.tf`)
   * s3_bucket_name - S3 bucket name which contains public keys (see `samples/s3_ssh_public_keys.tf`)
+  * s3_bucket_uri – S3 URI which contains the public keys. If this is specified, `s3_bucket_name` will be ignored.
   * vpc_id - VPC where bastion host should be created
   * subnet_id - Subnet ID where instance should be created
   * keys_update_frequency - How often to update keys. A cron timespec or an empty string to turn off (default).
@@ -48,7 +53,7 @@ If you want to assign EIP and use Route53 to bastion instance add something like
       vpc = true
       instance = "${module.bastion.instance_id}"
     }
-    
+
     resource "aws_route53_record" "bastion" {
       zone_id = "..."
       name    = "bastion.example.com"
@@ -70,7 +75,7 @@ or even like this:
     $ ssh ubuntu@bastion.example.com
 
 PS: In some cases you may consider adding flag `-A` to ssh command to enable forwarding of the authentication agent connection.
-    
+
 ##Authors
 
 Created and maintained by [Anton Babenko](https://github.com/antonbabenko).

--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,7 @@ resource "template_file" "user_data" {
 
   vars {
     s3_bucket_name              = "${var.s3_bucket_name}"
+    s3_bucket_uri               = "${var.s3_bucket_uri}"
     ssh_user                    = "${var.ssh_user}"
     keys_update_frequency       = "${var.keys_update_frequency}"
     enable_hourly_cron_updates  = "${var.enable_hourly_cron_updates}"

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,7 @@ resource "template_file" "user_data" {
   vars {
     s3_bucket_name              = "${var.s3_bucket_name}"
     ssh_user                    = "${var.ssh_user}"
+    keys_update_frequency       = "${var.keys_update_frequency}"
     enable_hourly_cron_updates  = "${var.enable_hourly_cron_updates}"
     additional_user_data_script = "${var.additional_user_data_script}"
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,7 @@ output "instance_ip" {
 output "ssh_user" {
   value = "${var.ssh_user}"
 }
+
+output "security_group_id" {
+  value = "${aws_security_group.bastion.id}"
+}

--- a/user_data.sh
+++ b/user_data.sh
@@ -60,10 +60,17 @@ chmod 755 /home/${ssh_user}/update_ssh_authorized_keys.sh
 # Execute now
 su ${ssh_user} -c /home/${ssh_user}/update_ssh_authorized_keys.sh
 
+# Be backwards compatible with old cron update enabler
+if [ "${enable_hourly_cron_updates}" = 'true' -a -z "${keys_update_frequency}" ]; then
+  keys_update_frequency="0 * * * *"
+else
+  keys_update_frequency=${keys_update_frequency}
+fi
+
 # Add to cron
-if (( ${enable_hourly_cron_updates} )); then
+if [ -z "$keys_update_frequency" ]; then
   croncmd="/home/${ssh_user}/update_ssh_authorized_keys.sh"
-  cronjob="0 * * * * $croncmd"
+  cronjob="$keys_update_frequency $croncmd"
   ( crontab -u ${ssh_user} -l | grep -v "$croncmd" ; echo "$cronjob" ) | crontab -u ${ssh_user} -
 fi
 

--- a/user_data.sh
+++ b/user_data.sh
@@ -20,38 +20,33 @@ pip install --upgrade awscli
 cat <<"EOF" > /home/${ssh_user}/update_ssh_authorized_keys.sh
 #!/usr/bin/env bash
 
-BUCKET=${s3_bucket_name}
+set -e
+
+BUCKET_NAME=${s3_bucket_name}
+BUCKET_URI=${s3_bucket_uri}
 SSH_USER=${ssh_user}
 MARKER="# KEYS_BELOW_WILL_BE_UPDATED_BY_TERRAFORM"
+KEYS_FILE=/home/$SSH_USER/.ssh/authorized_keys
+TEMP_KEYS_FILE=$(mktemp /tmp/authorized_keys.XXXXXX)
+PUB_KEYS_DIR=/home/$SSH_USER/pub_key_files/
 
-mkdir -p /home/$SSH_USER/pub_key_files/
+[[ -z $BUCKET_URI ]] && BUCKET_URI="s3://$BUCKET_NAME/"
 
-# Add marker, if not present
-if ! grep -Fxq "$MARKER" /home/$SSH_USER/.ssh/authorized_keys;
-then
-  echo "
-$MARKER" >> /home/$SSH_USER/.ssh/authorized_keys
-fi
+mkdir -p $PUB_KEYS_DIR
 
-for key in `aws s3api list-objects --bucket $BUCKET | jq -r '.Contents[].Key'`
-do
-  aws s3 cp s3://$BUCKET/$key /home/$SSH_USER/pub_key_files/ > /dev/null
-done
+# Add marker, if not present, and copy static content.
+grep -Fxq "$MARKER" $KEYS_FILE || echo -e "\n$MARKER" >> $KEYS_FILE
+line=$(grep -n "$MARKER" $KEYS_FILE | cut -d ":" -f 1)
+head -n $line $KEYS_FILE > $TEMP_KEYS_FILE
 
-for f in /home/$SSH_USER/pub_key_files/*.pub ; do (cat "$f"; echo) >> /home/$SSH_USER/.ssh/tmp_authorized_keys; done
+# Synchronize the keys from the bucket.
+aws s3 sync --delete $BUCKET_URI $PUB_KEYS_DIR
+cat $PUB_KEYS_DIR/* >> $TEMP_KEYS_FILE
 
-# Append keys fetched from S3 bucket
-line=$(grep -n "$MARKER" /home/$SSH_USER/.ssh/authorized_keys | cut -d ":" -f 1)
-
-{ head -n $line /home/$SSH_USER/.ssh/authorized_keys; cat /home/$SSH_USER/.ssh/tmp_authorized_keys; } > /home/$SSH_USER/.ssh/authorized_keys
-
-sed -i /^$/d /home/$SSH_USER/.ssh/authorized_keys
-
-chown $SSH_USER:$SSH_USER /home/$SSH_USER/.ssh/authorized_keys
-chmod 600 /home/$SSH_USER/.ssh/authorized_keys
-
-rm /home/$SSH_USER/.ssh/tmp_authorized_keys
-
+# Move the new authorized keys in place.
+chown $SSH_USER:$SSH_USER $KEYS_FILE
+chmod 600 $KEYS_FILE
+mv $TEMP_KEYS_FILE $KEYS_FILE
 EOF
 
 chown ${ssh_user}:${ssh_user} /home/${ssh_user}/update_ssh_authorized_keys.sh
@@ -64,7 +59,7 @@ su ${ssh_user} -c /home/${ssh_user}/update_ssh_authorized_keys.sh
 if [ "${enable_hourly_cron_updates}" = 'true' -a -z "${keys_update_frequency}" ]; then
   keys_update_frequency="0 * * * *"
 else
-  keys_update_frequency=${keys_update_frequency}
+  keys_update_frequency="${keys_update_frequency}"
 fi
 
 # Add to cron

--- a/user_data.sh
+++ b/user_data.sh
@@ -68,7 +68,7 @@ else
 fi
 
 # Add to cron
-if [ -z "$keys_update_frequency" ]; then
+if [ -n "$keys_update_frequency" ]; then
   croncmd="/home/${ssh_user}/update_ssh_authorized_keys.sh"
   cronjob="$keys_update_frequency $croncmd"
   ( crontab -u ${ssh_user} -l | grep -v "$croncmd" ; echo "$cronjob" ) | crontab -u ${ssh_user} -

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,10 @@ variable "ssh_user" {
   default = "ubuntu"
 }
 variable "enable_hourly_cron_updates" {
-  default = false
+  default = "false"
+}
+variable "keys_update_frequency" {
+  default = ""
 }
 variable "additional_user_data_script" {
   default = ""

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,9 @@ variable "user_data_file" {
 }
 variable "s3_bucket_name" {
 }
+variable "s3_bucket_uri" {
+  default = ""
+}
 variable "s3_region" {
   default = "eu-west-1"
 }


### PR DESCRIPTION
This PR contains the following changes:

* Allow specifying how frequently to update the keys from S3 using a cron time specifier.
* Allow specifying the S3 location as an URI instead of a bucket name. This permits storing keys in a folder inside the bucket.
* Keys that are removed from the bucket will be removed from the host too. This is mostly what one would want, but it can be argued whether this should be configurable and default off.
* Expose the ID of the security group the bastion host is launched in.

It is meant to be backwards compatible, though some of the old parameters (specifically `s3_bucket_name` and `enable_hourly_cron_updates`) could be deprecated and eventually removed.

As part of this the sync script was simplified with mostly trivial changes. It uses `aws s3 sync` for synchronizing the keys, instead of doing this by hand. Maybe there was a reason for the more complicated implementation?