### PR TITLE
Use autoscaling group for bastion host

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tf_aws_bastion_s3_keys
 
-A Terraform module for creating bastion host on AWS EC2 and populate its
-~/.ssh/authorized_keys with public keys fetched from S3 bucket.
+A Terraform module for creating resilient bastion host using auto-scaling group (min=max=desired=1) and populate its
+`~/.ssh/authorized_keys` with public keys fetched from S3 bucket.
 
 This module can append public keys, setup cron to update them and run
 additional commands at the end of setup. Note that if it is set up to
@@ -12,23 +12,22 @@ Only SSH access is allowed to the bastion host.
 
 ## Input variables:
 
-  * name - Name (default, `bastion`)
-  * instance_type - Instance type (default, `t2.micro`)
-  * ami_id - AMI ID of Ubuntu (see `samples/ami.tf`)
-  * region - Region (default, `eu-west-1`)
-  * iam_instance_profile - IAM instance profile which is allowed to access S3 bucket (see `samples/iam.tf`)
-  * s3_bucket_name - S3 bucket name which contains public keys (see `samples/s3_ssh_public_keys.tf`)
-  * s3_bucket_uri – S3 URI which contains the public keys. If specified, `s3_bucket_name` will be ignored.
-  * vpc_id - VPC where bastion host should be created
-  * subnet_id - Subnet ID where instance should be created
-  * keys_update_frequency - How often to update keys. A cron timespec or an empty string to turn off (default).
-  * additional_user_data_script - Additional user-data script to run at the end.
+  * `name` - Name (default, `bastion`)
+  * `instance_type` - Instance type (default, `t2.micro`)
+  * `ami_id` - AMI ID of Ubuntu (see `samples/ami.tf`)
+  * `region` - Region (default, `eu-west-1`)
+  * `iam_instance_profile` - IAM instance profile which is allowed to access S3 bucket (see `samples/iam.tf`)
+  * `s3_bucket_name` - S3 bucket name which contains public keys (see `samples/s3_ssh_public_keys.tf`)
+  * `s3_bucket_uri `– S3 URI which contains the public keys. If specified, `s3_bucket_name` will be ignored
+  * `vpc_id` - VPC where bastion host should be created
+  * `subnet_ids` - Comma-separated list of subnet IDs where auto-scaling should create instances
+  * `keys_update_frequency` - How often to update keys. A cron timespec or an empty string to turn off (default)
+  * `additional_user_data_script` - Additional user-data script to run at the end
+  * `eip` - EIP to put into EC2 tag (can be used with scripts like https://github.com/skymill/aws-ec2-assign-elastic-ip, default - empty value)
 
 ## Outputs:
 
-  * instance_id - Bastion instance ID
   * ssh_user - SSH user to login to bastion
-  * instance_ip - Public IP of bastion instance
   * security_group_id - ID of the security group the bastion host is launched in.
 
 ## Example:
@@ -43,13 +42,27 @@ Basic example - In your terraform code add something like this:
       iam_instance_profile        = "s3-readonly"
       s3_bucket_name              = "public-keys-demo-bucket"
       vpc_id                      = "vpc-123456"
-      subnet_id                   = "subnet-123456"
+      subnet_ids                  = "subnet-123456,subnet-6789123,subnet-321321"
       keys_update_frequency       = "5,20,35,50 * * * *"
       additional_user_data_script = "date"
     }
 
-If you want to assign EIP and use Route53 to bastion instance add something like this:
+If you want to assign EIP to instance launched by auto-scaling group you can provide desired `eip` as module input
+and then execute `additional_user_data_script` which sets EIP. This way you can use Route53 with EIP, which will always
+point to existing bastion instance:
 
+    module "bastion" {
+      // see above
+      eip = ${aws_eip.bastion.public_ip}
+      additional_user_data_script = <<EOF
+        pip install aws-ec2-assign-elastic-ip
+        INSTANCE_ID=$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)
+        REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
+        EIP=$(aws ec2 describe-tags --filters "Name=resource-id,Values=${INSTANCE_ID}" "Name=key,Values=EIP" --output text --region ${REGION} --query 'Tags[*].Value')
+        aws-ec2-assign-elastic-ip --valid-ips $EIP
+      EOF"
+    }
+    
     resource "aws_eip" "bastion" {
       vpc = true
       instance = "${module.bastion.instance_id}"

--- a/main.tf
+++ b/main.tf
@@ -11,14 +11,22 @@ resource "aws_security_group" "bastion" {
     protocol    = "tcp"
     from_port   = 22
     to_port     = 22
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [
+      "0.0.0.0/0"
+    ]
   }
 
   egress {
     protocol    = -1
     from_port   = 0
     to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [
+      "0.0.0.0/0"
+    ]
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }
 
@@ -33,19 +41,69 @@ resource "template_file" "user_data" {
     enable_hourly_cron_updates  = "${var.enable_hourly_cron_updates}"
     additional_user_data_script = "${var.additional_user_data_script}"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
-resource "aws_instance" "bastion" {
-  ami                    = "${var.ami}"
-  instance_type          = "${var.instance_type}"
-  iam_instance_profile   = "${var.iam_instance_profile}"
-  subnet_id              = "${var.subnet_id}"
-  vpc_security_group_ids = ["${aws_security_group.bastion.id}"]
-  user_data              = "${template_file.user_data.rendered}"
+//resource "aws_instance" "bastion" {
+//  ami                    = "${var.ami}"
+//  instance_type          = "${var.instance_type}"
+//  iam_instance_profile   = "${var.iam_instance_profile}"
+//  subnet_id              = "${var.subnet_id}"
+//  vpc_security_group_ids = ["${aws_security_group.bastion.id}"]
+//  user_data              = "${template_file.user_data.rendered}"
+//
+//  count                  = 1
+//
+//  tags {
+//    Name = "${var.name}"
+//  }
+//}
 
-  count                  = 1
+resource "aws_launch_configuration" "bastion" {
+  name_prefix          = "${var.name}-"
+  image_id             = "${var.ami}"
+  instance_type        = "${var.instance_type}"
+  user_data            = "${template_file.user_data.rendered}"
+  security_groups      = [
+    "${aws_security_group.bastion.id}"
+  ]
+  iam_instance_profile = "${var.iam_instance_profile}"
 
-  tags {
-    Name = "${var.name}"
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "bastion" {
+  name                      = "${var.name}"
+  vpc_zone_identifier       = [
+    "${split(",", var.subnet_ids)}"
+  ]
+  desired_capacity          = "1"
+  min_size                  = "1"
+  max_size                  = "1"
+  health_check_grace_period = "60"
+  health_check_type         = "EC2"
+  force_delete              = false
+  wait_for_capacity_timeout = 0
+  launch_configuration      = "${aws_launch_configuration.bastion.name}"
+
+  tag {
+    key                 = "Name"
+    value               = "${var.name}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "EIP"
+    value               = "${var.eip}"
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,3 @@
-output "instance_id" {
-  value = "${aws_instance.bastion.id}"
-}
-
-output "instance_ip" {
-  value = "${aws_instance.bastion.public_ip}"
-}
-
 output "ssh_user" {
   value = "${var.ssh_user}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,9 +16,6 @@ variable "s3_bucket_name" {
 variable "s3_bucket_uri" {
   default = ""
 }
-variable "s3_region" {
-  default = "eu-west-1"
-}
 variable "ssh_user" {
   default = "ubuntu"
 }
@@ -36,5 +33,8 @@ variable "region" {
 }
 variable "vpc_id" {
 }
-variable "subnet_id" {
+variable "subnet_ids" {
+}
+variable "eip" {
+  default = ""
 }


### PR DESCRIPTION
This PR contains breaking changes - it will terminate running bastion EC2 instance and use ASG.

* Bastion hosts are now working inside autoscaling group supporting multiple subnets
* Added option to provide desired EIP as EC2 tag (see `README.md` for example code)