### PR TITLE
Ensure each key is on a newline

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -42,9 +42,7 @@ head -n $line $KEYS_FILE > $TEMP_KEYS_FILE
 # Synchronize the keys from the bucket.
 aws s3 sync --delete $BUCKET_URI $PUB_KEYS_DIR
 for filename in $PUB_KEYS_DIR/*; do
-    cat $filename >> $TEMP_KEYS_FILE
-    # Ensure each new key starts on a newline
-    sed -i -e '$a\' $TEMP_KEYS_FILE
+    sed 's/\n\?$/\n/' < $filename >> $TEMP_KEYS_FILE
 done
 
 # Move the new authorized keys in place.

--- a/user_data.sh
+++ b/user_data.sh
@@ -41,7 +41,11 @@ head -n $line $KEYS_FILE > $TEMP_KEYS_FILE
 
 # Synchronize the keys from the bucket.
 aws s3 sync --delete $BUCKET_URI $PUB_KEYS_DIR
-cat $PUB_KEYS_DIR/* >> $TEMP_KEYS_FILE
+for filename in $PUB_KEYS_DIR/*; do
+    cat $filename >> $TEMP_KEYS_FILE
+    # Ensure each new key starts on a newline
+    sed -i -e '$a\' $TEMP_KEYS_FILE
+done
 
 # Move the new authorized keys in place.
 chown $SSH_USER:$SSH_USER $KEYS_FILE


### PR DESCRIPTION
If the key files in s3 do not have newlines at the end of them this creates an invalid authorized key file on the server. This PR ensures the authorized key file is always valid.