### PR TITLE
Option to use instance public IP (not EIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Only SSH access is allowed to the bastion host.
   * `subnet_ids` - List of subnet IDs where auto-scaling should create instances
   * `keys_update_frequency` - How often to update keys. A cron timespec or an empty string to turn off (default)
   * `additional_user_data_script` - Additional user-data script to run at the end
+  * `associate_public_ip_address` - Whether to auto-assign public IP to the instance (by default - `false`)
   * `eip` - EIP to put into EC2 tag (can be used with scripts like https://github.com/skymill/aws-ec2-assign-elastic-ip, default - empty value)
 
 ## Outputs:

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,7 @@ resource "aws_launch_configuration" "bastion" {
     "${compact(concat(list(aws_security_group.bastion.id), split(",", "${var.security_group_ids}")))}"
   ]
   iam_instance_profile = "${var.iam_instance_profile}"
+  associate_public_ip_address = "${var.associate_public_ip_address}"
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -45,5 +45,5 @@ variable "eip" {
   default = ""
 }
 variable "associate_public_ip_address" {
-  default = "false"
+  default = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -44,3 +44,6 @@ variable "subnet_ids" {
 variable "eip" {
   default = ""
 }
+variable "associate_public_ip_address" {
+  default = "false"
+}


### PR DESCRIPTION
I found it handy to just allocate dynamic public IP instead of scripting EIP association. Please let me know what do you think.

By default set to `false` to maintain backwards compatibility