### PR TITLE
update

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -18,7 +18,7 @@ pip install --upgrade awscli
 ##############
 
 cat <<"EOF" > /home/${ssh_user}/update_ssh_authorized_keys.sh
-cat <<EOF > /home/ubuntu/.ssh/config
+cat <<EOF > /home/${ssh_user}/.ssh/config
 Host *
     StrictHostKeyChecking no
 EOF

--- a/user_data.sh
+++ b/user_data.sh
@@ -18,6 +18,10 @@ pip install --upgrade awscli
 ##############
 
 cat <<"EOF" > /home/${ssh_user}/update_ssh_authorized_keys.sh
+cat <<EOF > /home/ubuntu/.ssh/config
+Host *
+    StrictHostKeyChecking no
+EOF
 #!/usr/bin/env bash
 
 set -e

--- a/user_data.sh
+++ b/user_data.sh
@@ -49,13 +49,14 @@ done
 chown $SSH_USER:$SSH_USER $KEYS_FILE
 chmod 600 $KEYS_FILE
 mv $TEMP_KEYS_FILE $KEYS_FILE
+EOF
 
-cat <<"SSHCONFIG" > /home/${ssh_user}/.ssh/config
+cat <<"EOF" > /home/${ssh_user}/.ssh/config
 Host *
     StrictHostKeyChecking no
-SSHCONFIG
-
 EOF
+chmod 600 /home/${ssh_user}/.ssh/config
+chown ${ssh_user}:${ssh_user} /home/${ssh_user}/.ssh/config
 
 chown ${ssh_user}:${ssh_user} /home/${ssh_user}/update_ssh_authorized_keys.sh
 chmod 755 /home/${ssh_user}/update_ssh_authorized_keys.sh

--- a/user_data.sh
+++ b/user_data.sh
@@ -18,10 +18,6 @@ pip install --upgrade awscli
 ##############
 
 cat <<"EOF" > /home/${ssh_user}/update_ssh_authorized_keys.sh
-cat <<EOF > /home/${ssh_user}/.ssh/config
-Host *
-    StrictHostKeyChecking no
-EOF
 #!/usr/bin/env bash
 
 set -e
@@ -53,6 +49,12 @@ done
 chown $SSH_USER:$SSH_USER $KEYS_FILE
 chmod 600 $KEYS_FILE
 mv $TEMP_KEYS_FILE $KEYS_FILE
+
+cat <<"SSHCONFIG" > /home/${ssh_user}/.ssh/config
+Host *
+    StrictHostKeyChecking no
+SSHCONFIG
+
 EOF
 
 chown ${ssh_user}:${ssh_user} /home/${ssh_user}/update_ssh_authorized_keys.sh


### PR DESCRIPTION
* Sets `StrictHostKeyChecking no` for `~/.ssh/config` to allow for accessing hosts behind bastion host transparantly.

Example config (client):
```
Host 192.168.*
  User ubuntu
    ProxyCommand ssh -o 'ForwardAgent yes' ubuntu@bastion.example.com 'ssh-add && nc %h %p'
	UserKnownHostsFile=/dev/null
```