### PR TITLE
adding a conditional check for selinuxenabled binary

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -52,7 +52,7 @@ done
 chown $SSH_USER:$SSH_USER $KEYS_FILE
 chmod 600 $KEYS_FILE
 mv $TEMP_KEYS_FILE $KEYS_FILE
-if selinuxenabled; then
+if [[ ! $(command -v "selinuxenabled") ]]; then
     restorecon -R -v $KEYS_FILE
 fi
 EOF


### PR DESCRIPTION
* Checks for `selinuxenabled` before executing `restorecon -R -v $KEYS_FILE`

In favour of PR: https://github.com/terraform-community-modules/tf_aws_bastion_s3_keys/pull/21

To address issue: https://github.com/terraform-community-modules/tf_aws_bastion_s3_keys/issues/20

This is to allow for this code to work on non-RHEL based distro's.

@antonbabenko What do you think ?