### PR TITLE
Add associate address permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Only SSH access is allowed to the bastion host.
   * `instance_type` - Instance type (default, `t2.micro`)
   * `ami_id` - AMI ID of Ubuntu (see `samples/ami.tf`)
   * `region` - Region (default, `eu-west-1`)
-  * `iam_instance_profile` - IAM instance profile which is allowed to access S3 bucket (see `samples/iam.tf`)
+  * `iam_instance_profile` - IAM instance profile which is allowed to access S3 bucket (see `samples/iam_s3_readonly.tf`)
   * `s3_bucket_name` - S3 bucket name which contains public keys (see `samples/s3_ssh_public_keys.tf`)
   * `s3_bucket_uri `– S3 URI which contains the public keys. If specified, `s3_bucket_name` will be ignored
   * `vpc_id` - VPC where bastion host should be created
@@ -41,7 +41,7 @@ Basic example - In your terraform code add something like this:
       instance_type               = "t2.micro"
       ami                         = "ami-123456"
       region                      = "eu-west-1"
-      iam_instance_profile        = "s3-readonly"
+      iam_instance_profile        = "s3_readonly"
       s3_bucket_name              = "public-keys-demo-bucket"
       vpc_id                      = "vpc-123456"
       subnet_ids                  = ["subnet-123456", "subnet-6789123", "subnet-321321"]
@@ -51,11 +51,12 @@ Basic example - In your terraform code add something like this:
 
 If you want to assign EIP to instance launched by auto-scaling group you can provide desired `eip` as module input
 and then execute `additional_user_data_script` which sets EIP. This way you can use Route53 with EIP, which will always
-point to existing bastion instance:
+point to existing bastion instance.  You will also need to add allow_associateaddress permission to iam_instance_profile (see `samples/iam_allow_associateaddress.tf`):
 
     module "bastion" {
       // see above
       eip = "${aws_eip.bastion.public_ip}"
+      iam_instance_profile        = "s3_readonly-allow_associateaddress"
       additional_user_data_script = <<EOF
     REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | awk -F\" '{print $4}')
     INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)

--- a/main.tf
+++ b/main.tf
@@ -8,20 +8,22 @@ resource "aws_security_group" "bastion" {
   }
 
   ingress {
-    protocol    = "tcp"
-    from_port   = 22
-    to_port     = 22
+    protocol  = "tcp"
+    from_port = 22
+    to_port   = 22
+
     cidr_blocks = [
-      "0.0.0.0/0"
+      "0.0.0.0/0",
     ]
   }
 
   egress {
-    protocol    = -1
-    from_port   = 0
-    to_port     = 0
+    protocol  = -1
+    from_port = 0
+    to_port   = 0
+
     cidr_blocks = [
-      "0.0.0.0/0"
+      "0.0.0.0/0",
     ]
   }
 
@@ -59,16 +61,18 @@ data "template_file" "user_data" {
 //}
 
 resource "aws_launch_configuration" "bastion" {
-  name_prefix          = "${var.name}-"
-  image_id             = "${var.ami}"
-  instance_type        = "${var.instance_type}"
-  user_data            = "${data.template_file.user_data.rendered}"
-  security_groups      = [
-    "${compact(concat(list(aws_security_group.bastion.id), split(",", "${var.security_group_ids}")))}"
+  name_prefix   = "${var.name}-"
+  image_id      = "${var.ami}"
+  instance_type = "${var.instance_type}"
+  user_data     = "${data.template_file.user_data.rendered}"
+
+  security_groups = [
+    "${compact(concat(list(aws_security_group.bastion.id), split(",", "${var.security_group_ids}")))}",
   ]
-  iam_instance_profile = "${var.iam_instance_profile}"
+
+  iam_instance_profile        = "${var.iam_instance_profile}"
   associate_public_ip_address = "${var.associate_public_ip_address}"
-  key_name             = "${var.key_name}"
+  key_name                    = "${var.key_name}"
 
   lifecycle {
     create_before_destroy = true
@@ -76,10 +80,12 @@ resource "aws_launch_configuration" "bastion" {
 }
 
 resource "aws_autoscaling_group" "bastion" {
-  name                      = "${var.name}"
-  vpc_zone_identifier       = [
-    "${var.subnet_ids}"
+  name = "${var.name}"
+
+  vpc_zone_identifier = [
+    "${var.subnet_ids}",
   ]
+
   desired_capacity          = "1"
   min_size                  = "1"
   max_size                  = "1"
@@ -88,7 +94,8 @@ resource "aws_autoscaling_group" "bastion" {
   force_delete              = false
   wait_for_capacity_timeout = 0
   launch_configuration      = "${aws_launch_configuration.bastion.name}"
-  enabled_metrics           = [
+
+  enabled_metrics = [
     "GroupMinSize",
     "GroupMaxSize",
     "GroupDesiredCapacity",
@@ -96,7 +103,7 @@ resource "aws_autoscaling_group" "bastion" {
     "GroupPendingInstances",
     "GroupStandbyInstances",
     "GroupTerminatingInstances",
-    "GroupTotalInstances"
+    "GroupTotalInstances",
   ]
 
   tag {

--- a/samples/iam.tf
+++ b/samples/iam.tf
@@ -1,11 +1,11 @@
 # This is just a sample definition of IAM instance profile which is allowed to read-only from S3, and associate ElasticIP addresses.
-resource "aws_iam_instance_profile" "s3_readonly" {
-  name  = "s3-readonly"
-  roles = ["${aws_iam_role.s3_readonly.name}"]
+resource "aws_iam_instance_profile" "s3_readonly-allow_associateaddress" {
+  name  = "s3_readonly-allow_associateaddress"
+  roles = ["${aws_iam_role.s3_readonly-allow_associateaddress.name}"]
 }
 
-resource "aws_iam_role" "s3_readonly" {
-  name               = "s3-readonly-role"
+resource "aws_iam_role" "s3_readonly-allow_associateaddress" {
+  name               = "s3_readonly-allow_associateaddress-role"
   path               = "/"
   assume_role_policy = <<EOF
 {
@@ -24,9 +24,9 @@ resource "aws_iam_role" "s3_readonly" {
 EOF
 }
 
-resource "aws_iam_role_policy" "s3_readonly_policy" {
-  name   = "s3-readonly-policy"
-  role   = "${aws_iam_role.s3_readonly.id}"
+resource "aws_iam_role_policy" "s3_readonly-allow_associateaddress_policy" {
+  name   = "s3_readonly-allow_associateaddress-policy"
+  role   = "${aws_iam_role.s3_readonly-allow_associateaddress.id}"
   policy = <<EOF
 {
     "Version": "2012-10-17",

--- a/samples/iam.tf
+++ b/samples/iam.tf
@@ -35,6 +35,7 @@ resource "aws_iam_role_policy" "s3_readonly_policy" {
             "Sid": "Stmt1425916919000",
             "Effect": "Allow",
             "Action": [
+		"ec2:AssociateAddress",
                 "s3:List*",
                 "s3:Get*"
             ],

--- a/samples/iam.tf
+++ b/samples/iam.tf
@@ -1,4 +1,4 @@
-# This is just a sample definition of IAM instance profile which is allowed to read-only from S3
+# This is just a sample definition of IAM instance profile which is allowed to read-only from S3, and associate ElasticIP addresses.
 resource "aws_iam_instance_profile" "s3_readonly" {
   name  = "s3-readonly"
   roles = ["${aws_iam_role.s3_readonly.name}"]

--- a/samples/iam.tf
+++ b/samples/iam.tf
@@ -35,7 +35,7 @@ resource "aws_iam_role_policy" "s3_readonly_policy" {
             "Sid": "Stmt1425916919000",
             "Effect": "Allow",
             "Action": [
-		"ec2:AssociateAddress",
+                "ec2:AssociateAddress",
                 "s3:List*",
                 "s3:Get*"
             ],

--- a/samples/iam_allow_associateaddress.tf
+++ b/samples/iam_allow_associateaddress.tf
@@ -5,8 +5,9 @@ resource "aws_iam_instance_profile" "s3_readonly-allow_associateaddress" {
 }
 
 resource "aws_iam_role" "s3_readonly-allow_associateaddress" {
-  name               = "s3_readonly-allow_associateaddress-role"
-  path               = "/"
+  name = "s3_readonly-allow_associateaddress-role"
+  path = "/"
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -25,8 +26,9 @@ EOF
 }
 
 resource "aws_iam_role_policy" "s3_readonly-allow_associateaddress_policy" {
-  name   = "s3_readonly-allow_associateaddress-policy"
-  role   = "${aws_iam_role.s3_readonly-allow_associateaddress.id}"
+  name = "s3_readonly-allow_associateaddress-policy"
+  role = "${aws_iam_role.s3_readonly-allow_associateaddress.id}"
+
   policy = <<EOF
 {
     "Version": "2012-10-17",

--- a/samples/iam_s3_readonly.tf
+++ b/samples/iam_s3_readonly.tf
@@ -1,0 +1,48 @@
+# This is just a sample definition of IAM instance profile which is allowed to read-only from S3.
+resource "aws_iam_instance_profile" "s3_readonly" {
+  name  = "s3_readonly"
+  roles = ["${aws_iam_role.s3_readonly.name}"]
+}
+
+resource "aws_iam_role" "s3_readonly" {
+  name = "s3_readonly"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "s3_readonly_policy" {
+  name = "s3_readonly-policy"
+  role = "${aws_iam_role.s3_readonly.id}"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1425916919000",
+            "Effect": "Allow",
+            "Action": [
+                "s3:List*",
+                "s3:Get*"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}

--- a/samples/s3_ssh_public_keys.tf
+++ b/samples/s3_ssh_public_keys.tf
@@ -7,6 +7,7 @@ resource "aws_s3_bucket" "ssh_public_keys" {
   region = "eu-west-1"
   bucket = "public-keys-demo-bucket"
   acl    = "private"
+
   policy = <<EOF
 {
 	"Version": "2008-10-17",
@@ -30,12 +31,12 @@ EOF
 }
 
 resource "aws_s3_bucket_object" "ssh_public_keys" {
-  bucket     = "${aws_s3_bucket.ssh_public_keys.bucket}"
-  key        = "${element(split(",", var.ssh_public_key_names), count.index)}.pub"
+  bucket = "${aws_s3_bucket.ssh_public_keys.bucket}"
+  key    = "${element(split(",", var.ssh_public_key_names), count.index)}.pub"
 
   # Make sure that you put files into correct location and name them accordingly (`public_keys/{keyname}.pub`)
-  content    = "${file("public_keys/${element(split(",", var.ssh_public_key_names), count.index)}.pub")}"
-  count      = "${length(split(",", var.ssh_public_key_names))}"
+  content = "${file("public_keys/${element(split(",", var.ssh_public_key_names), count.index)}.pub")}"
+  count   = "${length(split(",", var.ssh_public_key_names))}"
 
   depends_on = ["aws_s3_bucket.ssh_public_keys"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,52 +1,65 @@
 variable "name" {
   default = "bastion"
 }
-variable "ami" {
-}
+
+variable "ami" {}
+
 variable "instance_type" {
   default = "t2.micro"
 }
-variable "iam_instance_profile" {
-}
+
+variable "iam_instance_profile" {}
+
 variable "user_data_file" {
   default = "user_data.sh"
 }
-variable "s3_bucket_name" {
-}
+
+variable "s3_bucket_name" {}
+
 variable "s3_bucket_uri" {
   default = ""
 }
+
 variable "ssh_user" {
   default = "ubuntu"
 }
+
 variable "enable_hourly_cron_updates" {
   default = "false"
 }
+
 variable "keys_update_frequency" {
   default = ""
 }
+
 variable "additional_user_data_script" {
   default = ""
 }
+
 variable "region" {
   default = "eu-west-1"
 }
-variable "vpc_id" {
-}
+
+variable "vpc_id" {}
+
 variable "security_group_ids" {
   description = "Comma seperated list of security groups to apply to the bastion."
   default     = ""
 }
+
 variable "subnet_ids" {
   default     = []
   description = "A list of subnet ids"
 }
+
 variable "eip" {
   default = ""
 }
+
 variable "associate_public_ip_address" {
   default = false
 }
+
 variable "key_name" {
- default = ""
+  default = ""
 }


### PR DESCRIPTION
When using this module with only s3 permissions, the instance fails to associate the created EIP when userdata runs.  Gives a permission denied error unless you allow it in the IAM policy.