### PR TITLE
Adding allowed_cidr var

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Only SSH access is allowed to the bastion host.
   * `associate_public_ip_address` - Whether to auto-assign public IP to the instance (by default - `false`)
   * `eip` - EIP to put into EC2 tag (can be used with scripts like https://github.com/skymill/aws-ec2-assign-elastic-ip, default - empty value)
   * `key_name` - Launch configuration key name to be applied to created instance(s).
+  * `allowed_cidr` - A list of CIDR Networks to allow ssh access to. Defaults to 0.0.0.0/0
 
 ## Outputs:
 

--- a/main.tf
+++ b/main.tf
@@ -6,28 +6,24 @@ resource "aws_security_group" "bastion" {
   tags {
     Name = "${var.name}"
   }
+}
 
-  ingress {
-    protocol  = "tcp"
-    from_port = 22
-    to_port   = 22
+resource "aws_security_group_rule" "ssh_ingress" {
+  type              = "ingress"
+  from_port         = "22"
+  to_port           = "22"
+  protocol          = "tcp"
+  cidr_blocks       = "${var.allowed_cidr}"
+  security_group_id = "${aws_security_group.bastion.id}"
+}
 
-    cidr_blocks =  "${var.allowed_cidr}"
-  }
-
-  egress {
-    protocol  = -1
-    from_port = 0
-    to_port   = 0
-
-    cidr_blocks = [
-      "0.0.0.0/0",
-    ]
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
+resource "aws_security_group_rule" "bastion_all_egress" {
+  type              = "egress"
+  from_port         = "0"
+  to_port           = "65535"
+  protocol          = "all"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.bastion.id}"
 }
 
 data "template_file" "user_data" {

--- a/main.tf
+++ b/main.tf
@@ -12,9 +12,7 @@ resource "aws_security_group" "bastion" {
     from_port = 22
     to_port   = 22
 
-    cidr_blocks = [
-      "0.0.0.0/0",
-    ]
+    cidr_blocks =  "${var.allowed_cidr}"
   }
 
   egress {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "allowed_cidr" {
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+  description = "A list of CIDR Networks to allow ssh access to."
+}
+
 variable "name" {
   default = "bastion"
 }


### PR DESCRIPTION
This should allow us to pass CIDR blocks to the Security Group, which
lets us use this module for internal bastion hosts, or bastion hosts
that shouldn't be open to the world.

If this gets accepted, could we also tag a new release? 

Thanks! 

