### PR TITLE
Add the ability to allow access based on security group ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
+## 1.2.3
+
+FEATURES:
+
+ * [GH-29] - Added Ability to pass a list of security groups to allow SSH access (tfhartmann)
+
 ## 1.2.2
 
 FEATURES:
 
- * [GH-28] - Added possibility to customize CIDR networks for SSH access
+ * [GH-28] - Added possibility to customize CIDR networks for SSH access (tfhartmann)
 
 ## 1.2.1
 
@@ -22,19 +28,19 @@ FEATURES:
 
  * [GH-6] - Ensure each key is on a newline (crumley)
  * [GH-5] - Allows specifying security group ids to be added to the bastion box(es) (crumley)
- 
+
 ## 1.1.0
 
 FEATURES:
 
  * [GH-4] - Bastion host is now starting in auto-scaling group (antonbabenko)
- 
+
 ## 1.0.1
 
 FEATURES:
 
- * [GH-3] - Allow specifying update frequency and S3 URI (bnordbo) 
- 
+ * [GH-3] - Allow specifying update frequency and S3 URI (bnordbo)
+
 ## 1.0.0
 
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Only SSH access is allowed to the bastion host.
   * `eip` - EIP to put into EC2 tag (can be used with scripts like https://github.com/skymill/aws-ec2-assign-elastic-ip, default - empty value)
   * `key_name` - Launch configuration key name to be applied to created instance(s).
   * `allowed_cidr` - A list of CIDR Networks to allow ssh access to. Defaults to 0.0.0.0/0
+  * `allowed_security_groups` - A list of Security Group ID's to allow access to. Defaults to empty list
 
 ## Outputs:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Only SSH access is allowed to the bastion host.
   * `eip` - EIP to put into EC2 tag (can be used with scripts like https://github.com/skymill/aws-ec2-assign-elastic-ip, default - empty value)
   * `key_name` - Launch configuration key name to be applied to created instance(s).
   * `allowed_cidr` - A list of CIDR Networks to allow ssh access to. Defaults to 0.0.0.0/0
-  * `allowed_security_groups` - A list of Security Group ID's to allow access to. Defaults to empty list
+  * `allowed_security_groups` - A list of Security Group ID's to allow access to the bastion host (useful if bastion is deployed internally) Defaults to empty list
 
 ## Outputs:
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Only SSH access is allowed to the bastion host.
   * `associate_public_ip_address` - Whether to auto-assign public IP to the instance (by default - `false`)
   * `eip` - EIP to put into EC2 tag (can be used with scripts like https://github.com/skymill/aws-ec2-assign-elastic-ip, default - empty value)
   * `key_name` - Launch configuration key name to be applied to created instance(s).
+  * `allowed_cidr` - A list of CIDR Networks to allow ssh access to. Defaults to 0.0.0.0/0
 
 ## Outputs:
 

--- a/main.tf
+++ b/main.tf
@@ -6,28 +6,24 @@ resource "aws_security_group" "bastion" {
   tags {
     Name = "${var.name}"
   }
+}
 
-  ingress {
-    protocol  = "tcp"
-    from_port = 22
-    to_port   = 22
+resource "aws_security_group_rule" "ssh_ingress" {
+  type              = "ingress"
+  from_port         = "22"
+  to_port           = "22"
+  protocol          = "tcp"
+  cidr_blocks       = "${var.allowed_cidr}"
+  security_group_id = "${aws_security_group.bastion.id}"
+}
 
-    cidr_blocks =  "${var.allowed_cidr}"
-  }
-
-  egress {
-    protocol  = -1
-    from_port = 0
-    to_port   = 0
-
-    cidr_blocks = [
-      "0.0.0.0/0",
-    ]
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
+resource "aws_security_group_rule" "bastion_all_egress" {
+  type              = "egress"
+  from_port         = "0"
+  to_port           = "65535"
+  protocol          = "all"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.bastion.id}"
 }
 
 data "template_file" "user_data" {

--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,16 @@ resource "aws_security_group_rule" "ssh_ingress" {
   security_group_id = "${aws_security_group.bastion.id}"
 }
 
+resource "aws_security_group_rule" "ssh_sg_ingress" {
+  count                    = "${length(var.allowed_security_groups)}"
+  type                     = "ingress"
+  from_port                = "22"
+  to_port                  = "22"
+  protocol                 = "tcp"
+  source_security_group_id = "${element(var.allowed_security_groups, count.index)}"
+  security_group_id        = "${aws_security_group.bastion.id}"
+}
+
 resource "aws_security_group_rule" "bastion_all_egress" {
   type              = "egress"
   from_port         = "0"

--- a/main.tf
+++ b/main.tf
@@ -12,9 +12,7 @@ resource "aws_security_group" "bastion" {
     from_port = 22
     to_port   = 22
 
-    cidr_blocks = [
-      "0.0.0.0/0",
-    ]
+    cidr_blocks =  "${var.allowed_cidr}"
   }
 
   egress {

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "allowed_cidr" {
   description = "A list of CIDR Networks to allow ssh access to."
 }
 
+variable "allowed_security_groups" {
+  type        = "list"
+  default     = []
+  description = "A list of Security Group ID's to allow access to."
+}
+
 variable "name" {
   default = "bastion"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "allowed_cidr" {
+  type        = "list"
+  default     = ["0.0.0.0/0"]
+  description = "A list of CIDR Networks to allow ssh access to."
+}
+
 variable "name" {
   default = "bastion"
 }


### PR DESCRIPTION
This is useful for internal bastion, so for example when you only want this host to be open to a particular SG rather then a CIDR range

Sorry about opening a second PR, I would have added to the previous one, but wasn't fast enough :p 