### PR TITLE
Access bastion host via elb

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,11 @@ output "ssh_user" {
 output "security_group_id" {
   value = "${aws_security_group.bastion.id}"
 }
+
+output "dns_name" {
+  value = "${aws_elb.bastion.dns_name}"
+}
+
+output "zone_id" {
+  value = "${aws_elb.bastion.zone_id}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -85,3 +85,8 @@ variable "associate_public_ip_address" {
 variable "key_name" {
   default = ""
 }
+
+variable "ssh_port" {
+  default     = "22"
+  description = "Inbound ssh port"
+}


### PR DESCRIPTION
This change adds a classic ELB in front of the instance, which makes it possible to assign a Route53 alias record.