### PR TITLE
Extra tags for the bastion host

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Only SSH access is allowed to the bastion host.
   * `allowed_cidr` - A list of CIDR Networks to allow ssh access to. Defaults to "0.0.0.0/0"
   * `allowed_ipv6_cidr` - A list of IPv6 CIDR Networks to allow ssh access to. Defaults to "::/0"
   * `allowed_security_groups` - A list of Security Group ID's to allow access to the bastion host (useful if bastion is deployed internally) Defaults to empty list
+  * `extra_tags` - Optional a list of Key/Values Tags to be associated to the bastion host (see [Interpolated Tags](https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html)) 
 
 ## Outputs:
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "bastion" {
-  name = "${var.name}"
-  vpc_id = "${var.vpc_id}"
+  name        = "${var.name}"
+  vpc_id      = "${var.vpc_id}"
   description = "Bastion security group (only SSH inbound access is allowed)"
 
   tags {
@@ -9,34 +9,39 @@ resource "aws_security_group" "bastion" {
 }
 
 resource "aws_security_group_rule" "ssh_ingress" {
-  type = "ingress"
-  from_port = "22"
-  to_port = "22"
-  protocol = "tcp"
-  cidr_blocks = "${var.allowed_cidr}"
-  ipv6_cidr_blocks = "${var.allowed_ipv6_cidr}"
+  type              = "ingress"
+  from_port         = "22"
+  to_port           = "22"
+  protocol          = "tcp"
+  cidr_blocks       = "${var.allowed_cidr}"
+  ipv6_cidr_blocks  = "${var.allowed_ipv6_cidr}"
   security_group_id = "${aws_security_group.bastion.id}"
 }
 
 resource "aws_security_group_rule" "ssh_sg_ingress" {
-  count = "${length(var.allowed_security_groups)}"
-  type = "ingress"
-  from_port = "22"
-  to_port = "22"
-  protocol = "tcp"
+  count                    = "${length(var.allowed_security_groups)}"
+  type                     = "ingress"
+  from_port                = "22"
+  to_port                  = "22"
+  protocol                 = "tcp"
   source_security_group_id = "${element(var.allowed_security_groups, count.index)}"
-  security_group_id = "${aws_security_group.bastion.id}"
+  security_group_id        = "${aws_security_group.bastion.id}"
 }
 
 resource "aws_security_group_rule" "bastion_all_egress" {
-  type = "egress"
+  type      = "egress"
   from_port = "0"
-  to_port = "65535"
-  protocol = "all"
+  to_port   = "65535"
+  protocol  = "all"
+
   cidr_blocks = [
-    "0.0.0.0/0"]
+    "0.0.0.0/0",
+  ]
+
   ipv6_cidr_blocks = [
-    "::/0"]
+    "::/0",
+  ]
+
   security_group_id = "${aws_security_group.bastion.id}"
 }
 
@@ -44,11 +49,11 @@ data "template_file" "user_data" {
   template = "${file("${path.module}/${var.user_data_file}")}"
 
   vars {
-    s3_bucket_name = "${var.s3_bucket_name}"
-    s3_bucket_uri = "${var.s3_bucket_uri}"
-    ssh_user = "${var.ssh_user}"
-    keys_update_frequency = "${var.keys_update_frequency}"
-    enable_hourly_cron_updates = "${var.enable_hourly_cron_updates}"
+    s3_bucket_name              = "${var.s3_bucket_name}"
+    s3_bucket_uri               = "${var.s3_bucket_uri}"
+    ssh_user                    = "${var.ssh_user}"
+    keys_update_frequency       = "${var.keys_update_frequency}"
+    enable_hourly_cron_updates  = "${var.enable_hourly_cron_updates}"
     additional_user_data_script = "${var.additional_user_data_script}"
   }
 }
@@ -69,19 +74,19 @@ data "template_file" "user_data" {
 //}
 
 resource "aws_launch_configuration" "bastion" {
-  name_prefix = "${var.name}-"
-  image_id = "${var.ami}"
-  instance_type = "${var.instance_type}"
-  user_data = "${data.template_file.user_data.rendered}"
+  name_prefix       = "${var.name}-"
+  image_id          = "${var.ami}"
+  instance_type     = "${var.instance_type}"
+  user_data         = "${data.template_file.user_data.rendered}"
   enable_monitoring = "${var.enable_monitoring}"
 
   security_groups = [
     "${compact(concat(list(aws_security_group.bastion.id), split(",", "${var.security_group_ids}")))}",
   ]
 
-  iam_instance_profile = "${var.iam_instance_profile}"
+  iam_instance_profile        = "${var.iam_instance_profile}"
   associate_public_ip_address = "${var.associate_public_ip_address}"
-  key_name = "${var.key_name}"
+  key_name                    = "${var.key_name}"
 
   lifecycle {
     create_before_destroy = true
@@ -95,14 +100,14 @@ resource "aws_autoscaling_group" "bastion" {
     "${var.subnet_ids}",
   ]
 
-  desired_capacity = "1"
-  min_size = "1"
-  max_size = "1"
+  desired_capacity          = "1"
+  min_size                  = "1"
+  max_size                  = "1"
   health_check_grace_period = "60"
-  health_check_type = "EC2"
-  force_delete = false
+  health_check_type         = "EC2"
+  force_delete              = false
   wait_for_capacity_timeout = 0
-  launch_configuration = "${aws_launch_configuration.bastion.name}"
+  launch_configuration      = "${aws_launch_configuration.bastion.name}"
 
   enabled_metrics = [
     "GroupMinSize",
@@ -122,7 +127,8 @@ resource "aws_autoscaling_group" "bastion" {
           map("key", "EIP", "value", "${var.eip}", "propagate_at_launch", true)
         ),
         var.extra_tags)
-      }"]
+      }",
+  ]
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 resource "aws_security_group" "bastion" {
-  name        = "${var.name}"
-  vpc_id      = "${var.vpc_id}"
+  name = "${var.name}"
+  vpc_id = "${var.vpc_id}"
   description = "Bastion security group (only SSH inbound access is allowed)"
 
   tags {
@@ -9,32 +9,34 @@ resource "aws_security_group" "bastion" {
 }
 
 resource "aws_security_group_rule" "ssh_ingress" {
-  type              = "ingress"
-  from_port         = "22"
-  to_port           = "22"
-  protocol          = "tcp"
-  cidr_blocks       = "${var.allowed_cidr}"
-  ipv6_cidr_blocks  = "${var.allowed_ipv6_cidr}"
+  type = "ingress"
+  from_port = "22"
+  to_port = "22"
+  protocol = "tcp"
+  cidr_blocks = "${var.allowed_cidr}"
+  ipv6_cidr_blocks = "${var.allowed_ipv6_cidr}"
   security_group_id = "${aws_security_group.bastion.id}"
 }
 
 resource "aws_security_group_rule" "ssh_sg_ingress" {
-  count                    = "${length(var.allowed_security_groups)}"
-  type                     = "ingress"
-  from_port                = "22"
-  to_port                  = "22"
-  protocol                 = "tcp"
+  count = "${length(var.allowed_security_groups)}"
+  type = "ingress"
+  from_port = "22"
+  to_port = "22"
+  protocol = "tcp"
   source_security_group_id = "${element(var.allowed_security_groups, count.index)}"
-  security_group_id        = "${aws_security_group.bastion.id}"
+  security_group_id = "${aws_security_group.bastion.id}"
 }
 
 resource "aws_security_group_rule" "bastion_all_egress" {
-  type              = "egress"
-  from_port         = "0"
-  to_port           = "65535"
-  protocol          = "all"
-  cidr_blocks       = ["0.0.0.0/0"]
-  ipv6_cidr_blocks  = ["::/0"]
+  type = "egress"
+  from_port = "0"
+  to_port = "65535"
+  protocol = "all"
+  cidr_blocks = [
+    "0.0.0.0/0"]
+  ipv6_cidr_blocks = [
+    "::/0"]
   security_group_id = "${aws_security_group.bastion.id}"
 }
 
@@ -42,11 +44,11 @@ data "template_file" "user_data" {
   template = "${file("${path.module}/${var.user_data_file}")}"
 
   vars {
-    s3_bucket_name              = "${var.s3_bucket_name}"
-    s3_bucket_uri               = "${var.s3_bucket_uri}"
-    ssh_user                    = "${var.ssh_user}"
-    keys_update_frequency       = "${var.keys_update_frequency}"
-    enable_hourly_cron_updates  = "${var.enable_hourly_cron_updates}"
+    s3_bucket_name = "${var.s3_bucket_name}"
+    s3_bucket_uri = "${var.s3_bucket_uri}"
+    ssh_user = "${var.ssh_user}"
+    keys_update_frequency = "${var.keys_update_frequency}"
+    enable_hourly_cron_updates = "${var.enable_hourly_cron_updates}"
     additional_user_data_script = "${var.additional_user_data_script}"
   }
 }
@@ -67,19 +69,19 @@ data "template_file" "user_data" {
 //}
 
 resource "aws_launch_configuration" "bastion" {
-  name_prefix   = "${var.name}-"
-  image_id      = "${var.ami}"
+  name_prefix = "${var.name}-"
+  image_id = "${var.ami}"
   instance_type = "${var.instance_type}"
-  user_data     = "${data.template_file.user_data.rendered}"
+  user_data = "${data.template_file.user_data.rendered}"
   enable_monitoring = "${var.enable_monitoring}"
 
   security_groups = [
     "${compact(concat(list(aws_security_group.bastion.id), split(",", "${var.security_group_ids}")))}",
   ]
 
-  iam_instance_profile        = "${var.iam_instance_profile}"
+  iam_instance_profile = "${var.iam_instance_profile}"
   associate_public_ip_address = "${var.associate_public_ip_address}"
-  key_name                    = "${var.key_name}"
+  key_name = "${var.key_name}"
 
   lifecycle {
     create_before_destroy = true
@@ -93,14 +95,14 @@ resource "aws_autoscaling_group" "bastion" {
     "${var.subnet_ids}",
   ]
 
-  desired_capacity          = "1"
-  min_size                  = "1"
-  max_size                  = "1"
+  desired_capacity = "1"
+  min_size = "1"
+  max_size = "1"
   health_check_grace_period = "60"
-  health_check_type         = "EC2"
-  force_delete              = false
+  health_check_type = "EC2"
+  force_delete = false
   wait_for_capacity_timeout = 0
-  launch_configuration      = "${aws_launch_configuration.bastion.name}"
+  launch_configuration = "${aws_launch_configuration.bastion.name}"
 
   enabled_metrics = [
     "GroupMinSize",
@@ -113,17 +115,14 @@ resource "aws_autoscaling_group" "bastion" {
     "GroupTotalInstances",
   ]
 
-  tag {
-    key                 = "Name"
-    value               = "${var.name}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key                 = "EIP"
-    value               = "${var.eip}"
-    propagate_at_launch = true
-  }
+  tags = [
+    "${concat(
+        list(
+          map("key", "Name", "value", "${var.name}", "propagate_at_launch", true),
+          map("key", "EIP", "value", "${var.eip}", "propagate_at_launch", true)
+        ),
+        var.extra_tags)
+      }"]
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -1,20 +1,26 @@
 variable "allowed_cidr" {
   type = "list"
+
   default = [
-    "0.0.0.0/0"]
+    "0.0.0.0/0",
+  ]
+
   description = "A list of CIDR Networks to allow ssh access to."
 }
 
 variable "allowed_ipv6_cidr" {
   type = "list"
+
   default = [
-    "::/0"]
+    "::/0",
+  ]
+
   description = "A list of IPv6 CIDR Networks to allow ssh access to."
 }
 
 variable "allowed_security_groups" {
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
   description = "A list of Security Group ID's to allow access to."
 }
 
@@ -23,8 +29,8 @@ variable "name" {
 }
 
 variable extra_tags {
-  type = "list"
-  default = []
+  type        = "list"
+  default     = []
   description = "A list of tags to associate to the bastion instance."
 }
 
@@ -74,11 +80,11 @@ variable "vpc_id" {}
 
 variable "security_group_ids" {
   description = "Comma seperated list of security groups to apply to the bastion."
-  default = ""
+  default     = ""
 }
 
 variable "subnet_ids" {
-  default = []
+  default     = []
   description = "A list of subnet ids"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,23 +1,31 @@
 variable "allowed_cidr" {
-  type        = "list"
-  default     = ["0.0.0.0/0"]
+  type = "list"
+  default = [
+    "0.0.0.0/0"]
   description = "A list of CIDR Networks to allow ssh access to."
 }
 
 variable "allowed_ipv6_cidr" {
-  type        = "list"
-  default     = ["::/0"]
+  type = "list"
+  default = [
+    "::/0"]
   description = "A list of IPv6 CIDR Networks to allow ssh access to."
 }
 
 variable "allowed_security_groups" {
-  type        = "list"
-  default     = []
+  type = "list"
+  default = []
   description = "A list of Security Group ID's to allow access to."
 }
 
 variable "name" {
   default = "bastion"
+}
+
+variable extra_tags {
+  type = "list"
+  default = []
+  description = "A list of tags to associate to the bastion instance."
 }
 
 variable "ami" {}
@@ -66,11 +74,11 @@ variable "vpc_id" {}
 
 variable "security_group_ids" {
   description = "Comma seperated list of security groups to apply to the bastion."
-  default     = ""
+  default = ""
 }
 
 variable "subnet_ids" {
-  default     = []
+  default = []
   description = "A list of subnet ids"
 }
 


### PR DESCRIPTION
Hi there, 

I've added some code to add extra tags so that a user can add additional tags to the bastion host on top of Name and EIP

```
variable extra_tags {
  default = [
    {
      key = "Foo"
      value = "Bar"
      propagate_at_launch = true
    },
    {
      key = "Baz"
      value = "Bam"
      propagate_at_launch = true
    },
  ]
}
```
Example from https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html
