### PR TITLE
feat: Added a flexible way to pass a custom user-data script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Only SSH access is allowed to the bastion host.
   * `subnet_ids` - List of subnet IDs where auto-scaling should create instances
   * `keys_update_frequency` - How often to update keys. A cron timespec or an empty string to turn off (default)
   * `additional_user_data_script` - Additional user-data script to run at the end
+  * `user_data_file` - Override whold user-data script to add some custom security policies or to add support for OS you prefer. If not specified (by default) standard script will be used.
   * `associate_public_ip_address` - Whether to auto-assign public IP to the instance (by default - `false`)
   * `eip` - EIP to put into EC2 tag (can be used with scripts like https://github.com/skymill/aws-ec2-assign-elastic-ip, default - empty value)
   * `key_name` - Launch configuration key name to be applied to created instance(s).

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "aws_security_group_rule" "bastion_all_egress" {
 }
 
 data "template_file" "user_data" {
-  template = "${file("${path.module}/${var.user_data_file}")}"
+  template = "${var.user_data_file != "" ? var.user_data_file : file("${path.module}/user_data.sh")}"
 
   vars {
     s3_bucket_name              = "${var.s3_bucket_name}"

--- a/variables.tf
+++ b/variables.tf
@@ -43,7 +43,8 @@ variable "instance_type" {
 variable "iam_instance_profile" {}
 
 variable "user_data_file" {
-  default = "user_data.sh"
+  description = "Contents of user data file to be processed"
+  default     = ""
 }
 
 variable "s3_bucket_name" {}


### PR DESCRIPTION
At the moment there are no ways to customize user-data.txt file, which may be a problem when using OS of unsupported types. This PR adds a new way to pass the whole script file at once.