### PR TITLE
Fix deprecation warning

### DIFF
--- a/samples/iam_s3_readonly.tf
+++ b/samples/iam_s3_readonly.tf
@@ -1,7 +1,7 @@
 # This is just a sample definition of IAM instance profile which is allowed to read-only from S3.
 resource "aws_iam_instance_profile" "s3_readonly" {
   name  = "s3_readonly"
-  roles = ["${aws_iam_role.s3_readonly.name}"]
+  role = "${aws_iam_role.s3_readonly.name}"
 }
 
 resource "aws_iam_role" "s3_readonly" {


### PR DESCRIPTION
Warnings:

  * aws_iam_instance_profile.s3_readonly: "roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile