### PR TITLE
Fix deprecation warning

### DIFF
--- a/samples/iam_allow_associateaddress.tf
+++ b/samples/iam_allow_associateaddress.tf
@@ -1,7 +1,7 @@
 # This is just a sample definition of IAM instance profile which is allowed to read-only from S3, and associate ElasticIP addresses.
 resource "aws_iam_instance_profile" "s3_readonly-allow_associateaddress" {
   name  = "s3_readonly-allow_associateaddress"
-  roles = ["${aws_iam_role.s3_readonly-allow_associateaddress.name}"]
+  role = "${aws_iam_role.s3_readonly-allow_associateaddress.name}"
 }
 
 resource "aws_iam_role" "s3_readonly-allow_associateaddress" {


### PR DESCRIPTION
Warnings:

  * aws_iam_instance_profile.s3_readonly-allow_associateaddress: "roles": [DEPRECATED] Use `role` instead. Only a single role can be passed to an IAM Instance Profile