### PR TITLE
Add AutoScalingGroup ID to output

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Only SSH access is allowed to the bastion host.
 
   * ssh_user - SSH user to login to bastion
   * security_group_id - ID of the security group the bastion host is launched in.
+  * asg_id - The ID of the AutoScalingGroup the bastion host is launched within. 
 
 ## Example:
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,7 @@ output "ssh_user" {
 output "security_group_id" {
   value = "${aws_security_group.bastion.id}"
 }
+
+output "asg_id" {
+  value = "${aws_autoscaling_group.bastion.id}"
+}


### PR DESCRIPTION
It's occasionally useful to tie the autoscaling group to other parts of our Terraform infrastructure (specifically, ALB target groups). This PR enables that by exposing the ASG ID as an output of the module.

This may resolve @robinbowes request in #33 too by allowing the ALB/ELB to be created outside of this module.