### PR TITLE
Add the root volume size as a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Only SSH access is allowed to the bastion host.
 
   * `name` - Name (default, `bastion`)
   * `instance_type` - Instance type (default, `t2.micro`)
+  * `instance_volume_size_gb` - The root volume size, in gigabytes (default, `8`)
   * `ami` - AMI ID of Ubuntu (see `samples/ami.tf`)
   * `region` - Region (default, `eu-west-1`)
   * `iam_instance_profile` - IAM instance profile which is allowed to access S3 bucket (see `samples/iam_s3_readonly.tf`)

--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,10 @@ resource "aws_launch_configuration" "bastion" {
     "${compact(concat(list(aws_security_group.bastion.id), split(",", "${var.security_group_ids}")))}",
   ]
 
+  root_block_device {
+    volume_size = "${var.instance_volume_size_gb}"
+  }
+
   iam_instance_profile        = "${var.iam_instance_profile}"
   associate_public_ip_address = "${var.associate_public_ip_address}"
   key_name                    = "${var.key_name}"

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,11 @@ variable "instance_type" {
   default = "t2.micro"
 }
 
+variable "instance_volume_size_gb" {
+  description = "The root volume size, in gigabytes"
+  default = "8"
+}
+
 variable "iam_instance_profile" {}
 
 variable "user_data_file" {


### PR DESCRIPTION
Sometimes it's handy to have a bit more space on the bastion host. 

This PR adds the `instance_volume_size_gb` variable, which alters the size of the root block device on the bastion host.