### PR TITLE
Replace older local keys with newer S3 keys

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -43,7 +43,7 @@ line=$(grep -n "$MARKER" $KEYS_FILE | cut -d ":" -f 1)
 head -n $line $KEYS_FILE > $TEMP_KEYS_FILE
 
 # Synchronize the keys from the bucket.
-aws s3 sync --delete $BUCKET_URI $PUB_KEYS_DIR
+aws s3 sync --delete --exact-timestamps $BUCKET_URI $PUB_KEYS_DIR
 for filename in $PUB_KEYS_DIR/*; do
     [ -f "$filename" ] || continue
     sed 's/\n\?$/\n/' < $filename >> $TEMP_KEYS_FILE


### PR DESCRIPTION
The default `aws s3 sync` behaviour makes updating keys in-place (without removing and re-adding) impossible, as only _newer_ local keys are overwritten.

This change makes the sync behave as expected: making the local state exactly match the remote state.