### PR TITLE
Added option to recreate bastion host if new configuration needs to be applied

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,9 +104,9 @@ resource "aws_autoscaling_group" "bastion" {
     "${var.subnet_ids}",
   ]
 
-  desired_capacity          = "1"
-  min_size                  = "1"
-  max_size                  = "1"
+  desired_capacity          = "${var.reload_scaling_group != "" ? 0 : 1}"
+  min_size                  = "${var.reload_scaling_group != "" ? 0 : 1}"
+  max_size                  = "${var.reload_scaling_group != "" ? 0 : 1}"
   health_check_grace_period = "60"
   health_check_type         = "EC2"
   force_delete              = false
@@ -137,4 +137,26 @@ resource "aws_autoscaling_group" "bastion" {
   lifecycle {
     create_before_destroy = true
   }
+}
+/*
+resource "aws_autoscaling_schedule" "bastion_reload_action_up" {
+  count                  = "${var.reload_scaling_group != "" ? 1 : 0}"
+  scheduled_action_name  = "reload_bastion_up"
+  min_size               = 0
+  max_size               = 0
+  desired_capacity       = 0
+  start_time             = "${timeadd(timestamp(), "5m")}"
+  end_time               = "${timeadd(timestamp(), "10m")}"
+  autoscaling_group_name = "${var.name}"
+}
+*/
+resource "aws_autoscaling_schedule" "bastion_reload_action_down" {
+  count                  = "${var.reload_scaling_group != "" ? 1 : 0}"
+  scheduled_action_name  = "reload_bastion_down"
+  min_size               = 1
+  max_size               = 1
+  desired_capacity       = 1
+  start_time             = "${timeadd(timestamp(), "5m")}"
+  // end_time               = "${timeadd(timestamp(), "15m")}"
+  autoscaling_group_name = "${var.name}"
 }

--- a/main.tf
+++ b/main.tf
@@ -138,18 +138,7 @@ resource "aws_autoscaling_group" "bastion" {
     create_before_destroy = true
   }
 }
-/*
-resource "aws_autoscaling_schedule" "bastion_reload_action_up" {
-  count                  = "${var.reload_scaling_group != "" ? 1 : 0}"
-  scheduled_action_name  = "reload_bastion_up"
-  min_size               = 0
-  max_size               = 0
-  desired_capacity       = 0
-  start_time             = "${timeadd(timestamp(), "5m")}"
-  end_time               = "${timeadd(timestamp(), "10m")}"
-  autoscaling_group_name = "${var.name}"
-}
-*/
+
 resource "aws_autoscaling_schedule" "bastion_reload_action_down" {
   count                  = "${var.reload_scaling_group != "" ? 1 : 0}"
   scheduled_action_name  = "reload_bastion_down"

--- a/variables.tf
+++ b/variables.tf
@@ -104,3 +104,9 @@ variable "associate_public_ip_address" {
 variable "key_name" {
   default = ""
 }
+
+variable "reload_scaling_group" {
+  default = ""
+  description = "Scale up and down bastion load balancing group so new user data take effect."
+}
+


### PR DESCRIPTION
In case of running bastion host, the module will create new configuration in AWS "Launch Configuration" which is then applied only after bastion termination. So if  `reload_scaling_group` variable is utilized, bastion host is terminated and new one is going to start by definition in `aws_autoscaling_schedule` in next five minutes.