### PR TITLE
Reload via name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Only SSH access is allowed to the bastion host.
   * `allowed_ipv6_cidr` - A list of IPv6 CIDR Networks to allow ssh access to. Defaults to "::/0"
   * `allowed_security_groups` - A list of Security Group ID's to allow access to the bastion host (useful if bastion is deployed internally) Defaults to empty list
   * `extra_tags` - Optional a list of Key/Values Tags to be associated to the bastion host (see [Interpolated Tags](https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html)) 
+  * `reload_bastion` - Whether to apply `aws_launch_configuration` and update instances in autoscaling group (by default - `false`)
 
 ## Outputs:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Only SSH access is allowed to the bastion host.
   * `allowed_ipv6_cidr` - A list of IPv6 CIDR Networks to allow ssh access to. Defaults to "::/0"
   * `allowed_security_groups` - A list of Security Group ID's to allow access to the bastion host (useful if bastion is deployed internally) Defaults to empty list
   * `extra_tags` - Optional a list of Key/Values Tags to be associated to the bastion host (see [Interpolated Tags](https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html)) 
-  * `reload_bastion` - Whether to apply `aws_launch_configuration` and update instances in autoscaling group (by default - `false`)
+  * `apply_changes_immediately` - Whether to apply `aws_launch_configuration` and update instances in autoscaling group (by default - `false`)
 
 ## Outputs:
 

--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,7 @@ resource "aws_launch_configuration" "bastion" {
 }
 
 resource "aws_autoscaling_group" "bastion" {
-  name = "${var.name}"
+  name = "${var.apply_changes_immediately ? aws_launch_configuration.bastion.name : var.name}"
 
   vpc_zone_identifier = [
     "${var.subnet_ids}",

--- a/variables.tf
+++ b/variables.tf
@@ -104,3 +104,8 @@ variable "associate_public_ip_address" {
 variable "key_name" {
   default = ""
 }
+
+variable "apply_changes_immediately" {
+  description = "Whether to apply the changes at once and recreate auto-scaling group"
+  default = false
+}


### PR DESCRIPTION
Adds variable `reload_bastion` to reload the bastion if the `aws_launch_configuration` needs to be applied right after new changes take place.