### PR TITLE
Support for Terraform 0.12 (fixes #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ This module can append public keys, setup cron to update them and run additional
 
 Only SSH access is allowed to the bastion host.
 
+
+## Terraform versions
+
+For Terraform 0.12, use the version from master:
+
+    source  = "github.com/terraform-community-modules/tf_aws_bastion_s3_keys"
+
+For Terraform 0.11, pin the module version like this:
+
+    source  = "github.com/terraform-community-modules/tf_aws_bastion_s3_keys?ref=v1.10.0"
+
 ## Input variables:
 
   * `name` - Name (default, `bastion`)

--- a/main.tf
+++ b/main.tf
@@ -125,31 +125,21 @@ resource "aws_autoscaling_group" "bastion" {
     "GroupTotalInstances",
   ]
 
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibilty in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
-  tags = [
-    concat(
-      [
-        {
-          "key"                 = "Name"
-          "value"               = var.name
-          "propagate_at_launch" = true
-        },
-        {
-          "key"                 = "EIP"
-          "value"               = var.eip
-          "propagate_at_launch" = true
-        },
-      ],
-      var.extra_tags,
-    ),
-  ]
+  tags = concat(
+    [
+      {
+        "key"                 = "Name"
+        "value"               = var.name
+        "propagate_at_launch" = true
+      },
+      {
+        "key"                 = "EIP"
+        "value"               = var.eip
+        "propagate_at_launch" = true
+      },
+    ],
+    var.extra_tags,
+  )
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 resource "aws_security_group" "bastion" {
-  name        = "${var.name}"
-  vpc_id      = "${var.vpc_id}"
+  name        = var.name
+  vpc_id      = var.vpc_id
   description = "Bastion security group (only SSH inbound access is allowed)"
 
-  tags {
-    Name = "${var.name}"
+  tags = {
+    Name = var.name
   }
 }
 
@@ -13,19 +13,19 @@ resource "aws_security_group_rule" "ssh_ingress" {
   from_port         = "22"
   to_port           = "22"
   protocol          = "tcp"
-  cidr_blocks       = "${var.allowed_cidr}"
-  ipv6_cidr_blocks  = "${var.allowed_ipv6_cidr}"
-  security_group_id = "${aws_security_group.bastion.id}"
+  cidr_blocks       = var.allowed_cidr
+  ipv6_cidr_blocks  = var.allowed_ipv6_cidr
+  security_group_id = aws_security_group.bastion.id
 }
 
 resource "aws_security_group_rule" "ssh_sg_ingress" {
-  count                    = "${length(var.allowed_security_groups)}"
+  count                    = length(var.allowed_security_groups)
   type                     = "ingress"
   from_port                = "22"
   to_port                  = "22"
   protocol                 = "tcp"
-  source_security_group_id = "${element(var.allowed_security_groups, count.index)}"
-  security_group_id        = "${aws_security_group.bastion.id}"
+  source_security_group_id = element(var.allowed_security_groups, count.index)
+  security_group_id        = aws_security_group.bastion.id
 }
 
 resource "aws_security_group_rule" "bastion_all_egress" {
@@ -42,19 +42,19 @@ resource "aws_security_group_rule" "bastion_all_egress" {
     "::/0",
   ]
 
-  security_group_id = "${aws_security_group.bastion.id}"
+  security_group_id = aws_security_group.bastion.id
 }
 
 data "template_file" "user_data" {
-  template = "${file("${path.module}/${var.user_data_file}")}"
+  template = file("${path.module}/${var.user_data_file}")
 
-  vars {
-    s3_bucket_name              = "${var.s3_bucket_name}"
-    s3_bucket_uri               = "${var.s3_bucket_uri}"
-    ssh_user                    = "${var.ssh_user}"
-    keys_update_frequency       = "${var.keys_update_frequency}"
-    enable_hourly_cron_updates  = "${var.enable_hourly_cron_updates}"
-    additional_user_data_script = "${var.additional_user_data_script}"
+  vars = {
+    s3_bucket_name              = var.s3_bucket_name
+    s3_bucket_uri               = var.s3_bucket_uri
+    ssh_user                    = var.ssh_user
+    keys_update_frequency       = var.keys_update_frequency
+    enable_hourly_cron_updates  = var.enable_hourly_cron_updates
+    additional_user_data_script = var.additional_user_data_script
   }
 }
 
@@ -75,22 +75,25 @@ data "template_file" "user_data" {
 
 resource "aws_launch_configuration" "bastion" {
   name_prefix       = "${var.name}-"
-  image_id          = "${var.ami}"
-  instance_type     = "${var.instance_type}"
-  user_data         = "${data.template_file.user_data.rendered}"
-  enable_monitoring = "${var.enable_monitoring}"
+  image_id          = var.ami
+  instance_type     = var.instance_type
+  user_data         = data.template_file.user_data.rendered
+  enable_monitoring = var.enable_monitoring
 
-  security_groups = [
-    "${compact(concat(list(aws_security_group.bastion.id), split(",", "${var.security_group_ids}")))}",
-  ]
+  security_groups = compact(
+    concat(
+      [aws_security_group.bastion.id],
+      split(",", var.security_group_ids),
+    ),
+  )
 
   root_block_device {
-    volume_size = "${var.instance_volume_size_gb}"
+    volume_size = var.instance_volume_size_gb
   }
 
-  iam_instance_profile        = "${var.iam_instance_profile}"
-  associate_public_ip_address = "${var.associate_public_ip_address}"
-  key_name                    = "${var.key_name}"
+  iam_instance_profile        = var.iam_instance_profile
+  associate_public_ip_address = var.associate_public_ip_address
+  key_name                    = var.key_name
 
   lifecycle {
     create_before_destroy = true
@@ -98,11 +101,9 @@ resource "aws_launch_configuration" "bastion" {
 }
 
 resource "aws_autoscaling_group" "bastion" {
-  name = "${var.apply_changes_immediately ? aws_launch_configuration.bastion.name : var.name}"
+  name = var.apply_changes_immediately ? aws_launch_configuration.bastion.name : var.name
 
-  vpc_zone_identifier = [
-    "${var.subnet_ids}",
-  ]
+  vpc_zone_identifier = var.subnet_ids
 
   desired_capacity          = "1"
   min_size                  = "1"
@@ -111,7 +112,7 @@ resource "aws_autoscaling_group" "bastion" {
   health_check_type         = "EC2"
   force_delete              = false
   wait_for_capacity_timeout = 0
-  launch_configuration      = "${aws_launch_configuration.bastion.name}"
+  launch_configuration      = aws_launch_configuration.bastion.name
 
   enabled_metrics = [
     "GroupMinSize",
@@ -124,17 +125,34 @@ resource "aws_autoscaling_group" "bastion" {
     "GroupTotalInstances",
   ]
 
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibilty in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
   tags = [
-    "${concat(
-        list(
-          map("key", "Name", "value", "${var.name}", "propagate_at_launch", true),
-          map("key", "EIP", "value", "${var.eip}", "propagate_at_launch", true)
-        ),
-        var.extra_tags)
-      }",
+    concat(
+      [
+        {
+          "key"                 = "Name"
+          "value"               = var.name
+          "propagate_at_launch" = true
+        },
+        {
+          "key"                 = "EIP"
+          "value"               = var.eip
+          "propagate_at_launch" = true
+        },
+      ],
+      var.extra_tags,
+    ),
   ]
 
   lifecycle {
     create_before_destroy = true
   }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,12 @@
 output "ssh_user" {
-  value = "${var.ssh_user}"
+  value = var.ssh_user
 }
 
 output "security_group_id" {
-  value = "${aws_security_group.bastion.id}"
+  value = aws_security_group.bastion.id
 }
 
 output "asg_id" {
-  value = "${aws_autoscaling_group.bastion.id}"
+  value = aws_autoscaling_group.bastion.id
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "name" {
 }
 
 variable "extra_tags" {
-  type        = list(string)
+  type        = list(object({ key=string, value=string, propagate_at_launch=bool }))
   default     = []
   description = "A list of tags to associate to the bastion instance."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "allowed_cidr" {
-  type = "list"
+  type = list(string)
 
   default = [
     "0.0.0.0/0",
@@ -9,7 +9,7 @@ variable "allowed_cidr" {
 }
 
 variable "allowed_ipv6_cidr" {
-  type = "list"
+  type = list(string)
 
   default = [
     "::/0",
@@ -19,7 +19,7 @@ variable "allowed_ipv6_cidr" {
 }
 
 variable "allowed_security_groups" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "A list of Security Group ID's to allow access to."
 }
@@ -28,13 +28,14 @@ variable "name" {
   default = "bastion"
 }
 
-variable extra_tags {
-  type        = "list"
+variable "extra_tags" {
+  type        = list(string)
   default     = []
   description = "A list of tags to associate to the bastion instance."
 }
 
-variable "ami" {}
+variable "ami" {
+}
 
 variable "instance_type" {
   default = "t2.micro"
@@ -45,13 +46,15 @@ variable "instance_volume_size_gb" {
   default     = "8"
 }
 
-variable "iam_instance_profile" {}
+variable "iam_instance_profile" {
+}
 
 variable "user_data_file" {
   default = "user_data.sh"
 }
 
-variable "s3_bucket_name" {}
+variable "s3_bucket_name" {
+}
 
 variable "s3_bucket_uri" {
   default = ""
@@ -81,7 +84,8 @@ variable "region" {
   default = "eu-west-1"
 }
 
-variable "vpc_id" {}
+variable "vpc_id" {
+}
 
 variable "security_group_ids" {
   description = "Comma seperated list of security groups to apply to the bastion."
@@ -109,3 +113,4 @@ variable "apply_changes_immediately" {
   description = "Whether to apply the changes at once and recreate auto-scaling group"
   default     = false
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Hello,

I tried upgrading the module to Terraform 0.12, the automated upgrade command `terraform 0.12upgrade`) does a good job.
I only had to solve manually one section (which had a comment explaining with the proper context).

I've also added a few lines to README pointing people to use the `v1.10.0` version if they're on Terraform 0.11.

Does this look good?