### PR TITLE
Use python3 for Ubuntu 18.04+

### DIFF
--- a/user_data.sh
+++ b/user_data.sh
@@ -7,7 +7,7 @@
 # Apt based distro
 if command -v apt-get &>/dev/null; then
   apt-get update
-  apt-get install python-pip jq -y
+  apt-get install python3-pip jq -y
 
 # Yum based distro
 elif command -v yum &>/dev/null; then
@@ -19,7 +19,7 @@ fi
 
 #####################
 
-pip install --upgrade awscli
+pip3 install --upgrade awscli
 
 ##############
 

--- a/user_data.sh
+++ b/user_data.sh
@@ -14,7 +14,7 @@ elif command -v yum &>/dev/null; then
   yum update -y
   # epel provides python-pip & jq
   yum install -y epel-release
-  yum install python-pip jq -y
+  yum install python3-pip jq -y
 fi
 
 #####################


### PR DESCRIPTION
The current user script doesn't work for Ubuntu LTS > 18.04 due to the fact that python3 is now the default python version.  I have confirmed that this PR successfully works with Ubuntu 20.04 LTS.

It won't be backwards compatible though, perhaps someone can suggest a way to do that?