### PR TITLE
Remove deprecated template plugin dependency

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ resource "aws_launch_configuration" "bastion" {
   name_prefix       = "${var.name}-"
   image_id          = var.ami
   instance_type     = var.instance_type
-  user_data         = templatefile("${path.module}/user_data.sh",{
+  user_data         = templatefile(var.user_data_file != "" ? var.user_data_file : "${path.module}/user_data.sh",{
     s3_bucket_name              = var.s3_bucket_name
     s3_bucket_uri               = var.s3_bucket_uri
     ssh_user                    = var.ssh_user

--- a/main.tf
+++ b/main.tf
@@ -45,19 +45,6 @@ resource "aws_security_group_rule" "bastion_all_egress" {
   security_group_id = aws_security_group.bastion.id
 }
 
-data "template_file" "user_data" {
-  template = var.user_data_file != "" ? var.user_data_file : file("${path.module}/user_data.sh")
-
-  vars = {
-    s3_bucket_name              = var.s3_bucket_name
-    s3_bucket_uri               = var.s3_bucket_uri
-    ssh_user                    = var.ssh_user
-    keys_update_frequency       = var.keys_update_frequency
-    enable_hourly_cron_updates  = var.enable_hourly_cron_updates
-    additional_user_data_script = var.additional_user_data_script
-  }
-}
-
 //resource "aws_instance" "bastion" {
 //  ami                    = "${var.ami}"
 //  instance_type          = "${var.instance_type}"
@@ -77,7 +64,14 @@ resource "aws_launch_configuration" "bastion" {
   name_prefix       = "${var.name}-"
   image_id          = var.ami
   instance_type     = var.instance_type
-  user_data         = data.template_file.user_data.rendered
+  user_data         = templatefile("${path.module}/user_data.sh",{
+    s3_bucket_name              = var.s3_bucket_name
+    s3_bucket_uri               = var.s3_bucket_uri
+    ssh_user                    = var.ssh_user
+    keys_update_frequency       = var.keys_update_frequency
+    enable_hourly_cron_updates  = var.enable_hourly_cron_updates
+    additional_user_data_script = var.additional_user_data_script
+  })
   enable_monitoring = var.enable_monitoring
 
   security_groups = compact(


### PR DESCRIPTION
I'm having issues with my mac m1 chip, so after investigated a little, i've found the issue in this library. The template_file data source was deprecated since terraform implemented the templatefile function in the 0.12 version. I hope it helps other devs!