### PR TITLE
[Security] Add support for IMDS V2 configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,12 @@ Only SSH access is allowed to the bastion host.
   * `allowed_cidr` - A list of CIDR Networks to allow ssh access to. Defaults to "0.0.0.0/0"
   * `allowed_ipv6_cidr` - A list of IPv6 CIDR Networks to allow ssh access to. Defaults to "::/0"
   * `allowed_security_groups` - A list of Security Group ID's to allow access to the bastion host (useful if bastion is deployed internally) Defaults to empty list
-  * `extra_tags` - Optional a list of Key/Values Tags to be associated to the bastion host (see [Interpolated Tags](https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html)) 
-
+  * `extra_tags` - Optional a list of Key/Values Tags to be associated to the bastion host (see [Interpolated Tags](https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html))
+  *  enable_http_endpoint - Whether the metadata service is available.
+  *  use_imds_v2 - Use (IMDSv2) Instance Metadata Service V2
+  *  http_put_response_hop_limit - The desired HTTP PUT response hop limit for instance metadata requests. Can be an integer from 1 to 64.
+  *  enable_http_protocol_ipv6 - Enables or disables the IPv6 endpoint for the instance metadata service.
+  *  enable_instance_metadata_tags - Enables or disables access to instance tags from the instance metadata service.
 ## Outputs:
 
   * ssh_user - SSH user to login to bastion
@@ -134,6 +138,11 @@ PS: In some cases you may consider adding flag `-A` to ssh command to enable for
 | subnet\_ids | A list of subnet ids | list | `[]` | no |
 | user\_data\_file |  | string | `"user_data.sh"` | no |
 | vpc\_id |  | string | n/a | yes |
+| enable_http_endpoint | Whether the metadata service is available | bool | `true` | no | 
+| use_imds_v2 | Use (IMDSv2) Instance Metadata Service V2 | bool | `false` | no |
+| http_put_response_hop_limit | The desired HTTP PUT response hop limit for instance metadata requests. Can be an integer from 1 to 64. | number | `1` | no |
+| enable_http_protocol_ipv6 | Enables or disables the IPv6 endpoint for the instance metadata service. | bool | `false` | no |
+| enable_instance_metadata_tags | Enables or disables access to instance tags from the instance metadata service. | bool | `false` |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ Only SSH access is allowed to the bastion host.
   *  enable_http_endpoint - Whether the metadata service is available.
   *  use_imds_v2 - Use (IMDSv2) Instance Metadata Service V2
   *  http_put_response_hop_limit - The desired HTTP PUT response hop limit for instance metadata requests. Can be an integer from 1 to 64.
-  *  enable_http_protocol_ipv6 - Enables or disables the IPv6 endpoint for the instance metadata service.
-  *  enable_instance_metadata_tags - Enables or disables access to instance tags from the instance metadata service.
+
 ## Outputs:
 
   * ssh_user - SSH user to login to bastion
@@ -141,8 +140,6 @@ PS: In some cases you may consider adding flag `-A` to ssh command to enable for
 | enable_http_endpoint | Whether the metadata service is available | bool | `true` | no | 
 | use_imds_v2 | Use (IMDSv2) Instance Metadata Service V2 | bool | `false` | no |
 | http_put_response_hop_limit | The desired HTTP PUT response hop limit for instance metadata requests. Can be an integer from 1 to 64. | number | `1` | no |
-| enable_http_protocol_ipv6 | Enables or disables the IPv6 endpoint for the instance metadata service. | bool | `false` | no |
-| enable_instance_metadata_tags | Enables or disables access to instance tags from the instance metadata service. | bool | `false` |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -68,8 +68,6 @@ data "template_file" "user_data" {
 //  http_endpoint               = var.enable_http_endpoint ? "enabled" : "disabled"
 //  http_tokens                 = var.use_imds_v2 ? "required" : "optional"
 //  http_put_response_hop_limit = var.http_put_response_hop_limit
-//  http_protocol_ipv6          = var.enable_http_protocol_ipv6 ? "enabled" : "disabled"
-//  instance_metadata_tags      = var.enable_instance_metadata_tags ? "enabled" : "disabled"
 //
 //  count                  = 1
 //

--- a/main.tf
+++ b/main.tf
@@ -105,8 +105,6 @@ resource "aws_launch_configuration" "bastion" {
     http_endpoint               = var.enable_http_endpoint ? "enabled" : "disabled"
     http_tokens                 = var.use_imds_v2 ? "required" : "optional"
     http_put_response_hop_limit = var.http_put_response_hop_limit
-    http_protocol_ipv6          = var.enable_http_protocol_ipv6 ? "enabled" : "disabled"
-    instance_metadata_tags      = var.enable_instance_metadata_tags ? "enabled" : "disabled"
   }
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,11 @@ data "template_file" "user_data" {
 //  subnet_id              = "${var.subnet_id}"
 //  vpc_security_group_ids = ["${aws_security_group.bastion.id}"]
 //  user_data              = "${template_file.user_data.rendered}"
+//  http_endpoint               = var.enable_http_endpoint ? "enabled" : "disabled"
+//  http_tokens                 = var.use_imds_v2 ? "required" : "optional"
+//  http_put_response_hop_limit = var.http_put_response_hop_limit
+//  http_protocol_ipv6          = var.enable_http_protocol_ipv6 ? "enabled" : "disabled"
+//  instance_metadata_tags      = var.enable_instance_metadata_tags ? "enabled" : "disabled"
 //
 //  count                  = 1
 //
@@ -94,6 +99,15 @@ resource "aws_launch_configuration" "bastion" {
   iam_instance_profile        = var.iam_instance_profile
   associate_public_ip_address = var.associate_public_ip_address
   key_name                    = var.key_name
+
+  # Doc: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration#metadata_options
+  metadata_options {
+    http_endpoint               = var.enable_http_endpoint ? "enabled" : "disabled"
+    http_tokens                 = var.use_imds_v2 ? "required" : "optional"
+    http_put_response_hop_limit = var.http_put_response_hop_limit
+    http_protocol_ipv6          = var.enable_http_protocol_ipv6 ? "enabled" : "disabled"
+    instance_metadata_tags      = var.enable_instance_metadata_tags ? "enabled" : "disabled"
+  }
 
   lifecycle {
     create_before_destroy = true

--- a/variables.tf
+++ b/variables.tf
@@ -132,16 +132,3 @@ variable "http_put_response_hop_limit" {
   type        = number
   default     = 1
 }
-
-variable "enable_http_protocol_ipv6" {
-  description = "Enables or disables the IPv6 endpoint for the instance metadata service."
-  type        = bool
-  default     = false
-}
-
-variable "enable_instance_metadata_tags" {
-  description = "Enables or disables access to instance tags from the instance metadata service."
-  type        = bool
-  default     = false
-}
-

--- a/variables.tf
+++ b/variables.tf
@@ -115,3 +115,33 @@ variable "apply_changes_immediately" {
   default     = false
 }
 
+variable "enable_http_endpoint" {
+  description = "Whether the metadata service is available."
+  type        = bool
+  default     = true
+}
+
+variable "use_imds_v2" {
+  description = "Use (IMDSv2) Instance Metadata Service V2"
+  type        = bool
+  default     = false
+}
+
+variable "http_put_response_hop_limit" {
+  description = "The desired HTTP PUT response hop limit for instance metadata requests."
+  type        = number
+  default     = 1
+}
+
+variable "enable_http_protocol_ipv6" {
+  description = "Enables or disables the IPv6 endpoint for the instance metadata service."
+  type        = bool
+  default     = false
+}
+
+variable "enable_instance_metadata_tags" {
+  description = "Enables or disables access to instance tags from the instance metadata service."
+  type        = bool
+  default     = false
+}
+


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration#metadata_options

Greatly inspired by https://github.com/Guimove/terraform-aws-bastion/pull/147

> Add support for the Instance Metadata Service V2 as using version 1 of the Instance Metadata Service is prone to publicly known weaknesses.